### PR TITLE
docs: add ecosystem cross-reference tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,21 @@ activation.
 - [Agent Skills Overview](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
 - [Engineering Blog](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
 - [Skills Repository](https://github.com/anthropics/skills)
+
+## Skills Ecosystem
+
+| Project | Purpose |
+|---------|---------|
+| [claude-code-toolkit](https://github.com/spences10/claude-code-toolkit) | Performance, productivity, ecosystem tools |
+| [svelte-skills-kit](https://github.com/spences10/svelte-skills-kit) | Svelte 5 & SvelteKit skills marketplace |
+| [claude-skills-cli](https://github.com/spences10/claude-skills-cli) | CLI for creating skills with validation |
+| [svelte-claude-skills](https://github.com/spences10/svelte-claude-skills) | Original Svelte skills collection |
+
+## Tools Ecosystem
+
+| Project | Purpose |
+|---------|---------|
+| [mcp-omnisearch](https://github.com/spences10/mcp-omnisearch) | Unified search MCP (Tavily, Kagi, GitHub) |
+| [mcp-sqlite-tools](https://github.com/spences10/mcp-sqlite-tools) | Safe SQLite operations MCP |
+| [mcpick](https://github.com/spences10/mcpick) | Dynamic MCP server toggling |
+| [cclog](https://github.com/spences10/cclog) | Claude Code transcript → SQLite |


### PR DESCRIPTION
## Summary
- Add **Skills Ecosystem** table: Links to related skills projects
- Add **Tools Ecosystem** table: Links to MCP servers and tools

Part of cross-linking all 4 skills repos for better discoverability.

## Test plan
- [ ] Verify tables render correctly on GitHub
- [ ] Verify all links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)